### PR TITLE
Allow adding IPv6 addresses to keepalived groups, and optionally use IPv6 for the signalling protocol

### DIFF
--- a/interface-templates/vrrp/vrrp-group/node.tag/multicast-on-ipv6/node.def
+++ b/interface-templates/vrrp/vrrp-group/node.tag/multicast-on-ipv6/node.def
@@ -1,0 +1,3 @@
+type: bool
+help: Send multicasts over IPv6 instead of IPv4
+default: true

--- a/interface-templates/vrrp/vrrp-group/node.tag/virtual-address/node.def
+++ b/interface-templates/vrrp/vrrp-group/node.tag/virtual-address/node.def
@@ -1,5 +1,5 @@
 multi:
-type: ipv4,ipv4net
+type: txt
 help: Virtual address [REQUIRED]
 
 syntax:expression: exec "
@@ -7,3 +7,5 @@ syntax:expression: exec "
 
 val_help: ipv4; Virtual IP address (up to 20 per group)
 val_help: ipv4net; Virtual IP address with prefix (up to 20 per group)
+val_help: ipv6; Virtual IPv6 address (up to 20 per group)
+val_help: ipv6net; Virtual IPv6 address with prefix (up to 20 per group)

--- a/scripts/vyatta-keepalived.pl
+++ b/scripts/vyatta-keepalived.pl
@@ -145,6 +145,11 @@ sub keepalived_get_values {
       next;
     }
 
+    my $multicast_on_ipv6 = 0;
+    if ($config->exists("multicast-on-ipv6")) {
+        $multicast_on_ipv6 = 1;
+    }
+
     my $use_vmac = 0;
     my $transition_intf = $intf;
     if ( $config->exists("rfc3768-compatibility") ) {
@@ -275,6 +280,9 @@ sub keepalived_get_values {
     $output .= "\tstate $init_state\n";
     $output .= "\tinterface $intf\n";
     $output .= "\tvirtual_router_id $group\n";
+    if ($multicast_on_ipv6) {
+        $output .= "\tnative_ipv6\n";
+    }
     if ($use_vmac) {
 	$output .= "\tuse_vmac $intf";
 	$output .= "v";


### PR DESCRIPTION
This is essentially the same patch as fee19f3209b13c87b328c6dc73dedd0a2708706a, but it takes the non-backwards-compatible part (which moves the actual VRRP messages to an IPv6 multicast group) and puts it behind a config variable. In my limited VM testing, this seems to Do The Right Thing, and it generally looks like the Keepalived config files that I'm using on regular Linux machines.

This is pursuant to http://bugzilla.vyos.net/show_bug.cgi?id=149

I've used Vyatta/vRouter for a while, but this is my first attempt to send a pull request to VyOS, so please let me know all the things I've done wrong.
