### PR TITLE
T105: add virtual-ipaddress-excluded type and use it for IPv6 support

### DIFF
--- a/interface-templates/vrrp/vrrp-group/node.tag/virtual-address-excluded/node.def
+++ b/interface-templates/vrrp/vrrp-group/node.tag/virtual-address-excluded/node.def
@@ -1,0 +1,11 @@
+multi:
+type: txt
+help: Virtual address (not included in VRRP packet)
+
+syntax:expression: exec "
+       if [[ '$VAR(@)' == '*/' ]]; then /opt/vyatta/sbin/valid_address $VAR(@); fi"
+
+val_help: ipv4; Virtual IP address
+val_help: ipv4net; Virtual IP address with prefix
+val_help: ipv6; Virtual IP address
+val_help: ipv6net; Virtual IP address with prefix

--- a/lib/Vyatta/VRRP/OPMode.pm
+++ b/lib/Vyatta/VRRP/OPMode.pm
@@ -111,7 +111,7 @@ sub wait_for_data {
 
 sub process_data {
   my ($dh) = @_;
-  my ($instance, $interface, $in_sync, $in_vip);
+  my ($instance, $interface, $in_sync, $in_vip, $in_vip_excluded);
   kill 'SIGUSR1', get_pid();
   wait_for_data($DATAFILE);
   open my $DATA, '<',  $DATAFILE;
@@ -122,6 +122,7 @@ sub process_data {
       $instance = $2;
       $in_sync = undef;
       $in_vip = undef;
+      $in_vip_excluded = undef;
       $dh->{'instances'}->{$interface}->{$instance} = {};
       next;
     };
@@ -129,11 +130,20 @@ sub process_data {
       $instance = $1;
       $interface = undef;
       $in_vip = undef;
+      $in_vip_excluded = undef;
       my $state = $2;
       $in_sync = 1;
       add_to_datahash $dh, $interface, $instance, $in_sync, 'state', $state;
       next;
     };
+    if ($in_vip_excluded) {
+      m/(.*?) dev (.*)/ && do {
+        $dh->{'instances'}->{$interface}->{$instance}->{vips_excluded} = 
+        [ $dh->{'instances'}->{$interface}->{$instance}->{vips_excluded} ? 
+          @{$dh->{'instances'}->{$interface}->{$instance}->{vips_excluded}} : (),
+          trim $1 ];
+      };
+    }
     if ($in_vip){
       m/(.*?) dev (.*)/ && do {
         $dh->{'instances'}->{$interface}->{$instance}->{vips} = 
@@ -145,7 +155,11 @@ sub process_data {
     m/(.*?) = (.*)/ && do {
       $in_vip = undef;
       add_to_datahash $dh, $interface, $instance, $in_sync, $1, $2;
-      m/Virtual IP/ && do {$in_vip = 1};
+      if (m/Virtual IP Excluded/) {
+        $in_vip_excluded = 1; $in_vip = undef;
+      } elsif (m/Virtual IP/) {
+        $in_vip = 1 ; $in_vip_excluded = undef;
+      }
       next;
     };
   }
@@ -265,6 +279,12 @@ sub print_detail {
       printf "  VIP count:\t\t\t%s\n",
         $dh->{instances}->{$interface}->{$vrid}->{'virtual-ip'};
       foreach my $vip (@{$dh->{instances}->{$interface}->{$vrid}->{vips}}){
+         printf "    %s\n", $vip;
+      }
+      printf "\n";
+      printf "  VIP count (excluded):\t\t%s\n",
+        $dh->{instances}->{$interface}->{$vrid}->{'virtual-ip-excluded'};
+      foreach my $vip (@{$dh->{instances}->{$interface}->{$vrid}->{vips_excluded}}){
          printf "    %s\n", $vip;
       }
       printf "\n";

--- a/scripts/vyatta-keepalived.pl
+++ b/scripts/vyatta-keepalived.pl
@@ -145,10 +145,12 @@ sub keepalived_get_values {
       next;
     }
 
+    my @vips_excluded = $config->returnValues("virtual-address-excluded");
+
     my $use_vmac = 0;
     my $transition_intf = $intf;
     if ( $config->exists("rfc3768-compatibility") ) {
-	$use_vmac = 1;
+        $use_vmac = 1;
         $transition_intf = "$intf"."v"."$group";
     }
 
@@ -276,9 +278,9 @@ sub keepalived_get_values {
     $output .= "\tinterface $intf\n";
     $output .= "\tvirtual_router_id $group\n";
     if ($use_vmac) {
-	$output .= "\tuse_vmac $intf";
-	$output .= "v";
-	$output .= "$group\n";
+      $output .= "\tuse_vmac $intf";
+      $output .= "v";
+      $output .= "$group\n";
     }
     $output .= "\tpriority $priority\n";
     if ( $preempt eq "false" ) {
@@ -301,6 +303,12 @@ sub keepalived_get_values {
       $output .= "\t\t$vip\n";
     }
     $output .= "\t\}\n";
+    if ( defined @vips_excluded ) {
+      $output .= "\tvirtual_ipaddress_excluded \{\n";
+      foreach my $vip (@vips_excluded) {
+        $output .= "\t\t$vip\n";
+      }
+    }
     if ($run_master_script ne 'null') {
       $output .= "\tnotify_master \"$state_transition_script master ";
       $output .= "$intf $group $transition_intf \'$run_master_script\' @vips\" \n";

--- a/scripts/vyatta-keepalived.pl
+++ b/scripts/vyatta-keepalived.pl
@@ -308,6 +308,7 @@ sub keepalived_get_values {
       foreach my $vip (@vips_excluded) {
         $output .= "\t\t$vip\n";
       }
+      $output .= "\t\}\n";
     }
     if ($run_master_script ne 'null') {
       $output .= "\tnotify_master \"$state_transition_script master ";


### PR DESCRIPTION
- Allows adding "excluded" ipaddresses to a VRRP group. This is keepalived termiology; these are IP addresses which are managed by keepalived but not included in the VRRP packet. Essentially, this is synctactic sugar around having notify scripts that add/remove extra addresses. These are often used to surpass the 20-address limit
- Allows IPv6 addresses to be added to virtual-ipaddress-excluded

This might be a better approach than #5. Discussion is occurring at [T105](https://phabricator.vyos.net/T105).
