### PR TITLE
Add support for virtual_routes

### DIFF
--- a/interface-templates/vrrp/vrrp-group/node.tag/virtual-route/node.def
+++ b/interface-templates/vrrp/vrrp-group/node.tag/virtual-route/node.def
@@ -1,0 +1,7 @@
+tag:
+type: ipv4net
+help: Virtual route
+syntax:expression: exec "${vyatta_sbindir}/check_prefix_boundary $VAR(@)"
+
+commit:expression: $VAR(./next-hop/) != "" || $VAR(./blackhole/) != ""; \
+                   "Must add either a next-hop or blackhole for route $VAR(@)"

--- a/interface-templates/vrrp/vrrp-group/node.tag/virtual-route/node.tag/blackhole/node.def
+++ b/interface-templates/vrrp/vrrp-group/node.tag/virtual-route/node.tag/blackhole/node.def
@@ -1,0 +1,1 @@
+help: Silently discard pkts when matched

--- a/interface-templates/vrrp/vrrp-group/node.tag/virtual-route/node.tag/next-hop/node.def
+++ b/interface-templates/vrrp/vrrp-group/node.tag/virtual-route/node.tag/next-hop/node.def
@@ -1,0 +1,2 @@
+type: ipv4
+help: Next-hop router [REQUIRED]

--- a/lib/Vyatta/VRRP/OPMode.pm
+++ b/lib/Vyatta/VRRP/OPMode.pm
@@ -111,7 +111,7 @@ sub wait_for_data {
 
 sub process_data {
   my ($dh) = @_;
-  my ($instance, $interface, $in_sync, $in_vip);
+  my ($instance, $interface, $in_sync, $in_vip, $in_vroute);
   kill 'SIGUSR1', get_pid();
   wait_for_data($DATAFILE);
   open my $DATA, '<',  $DATAFILE;
@@ -122,6 +122,7 @@ sub process_data {
       $instance = $2;
       $in_sync = undef;
       $in_vip = undef;
+      $in_vroute = undef;
       $dh->{'instances'}->{$interface}->{$instance} = {};
       next;
     };
@@ -129,12 +130,19 @@ sub process_data {
       $instance = $1;
       $interface = undef;
       $in_vip = undef;
+      $in_vroute = undef;
       my $state = $2;
       $in_sync = 1;
       add_to_datahash $dh, $interface, $instance, $in_sync, 'state', $state;
       next;
     };
-    if ($in_vip){
+    if ($in_vroute){
+      $dh->{'instances'}->{$interface}->{$instance}->{vroutes} = 
+      [ $dh->{'instances'}->{$interface}->{$instance}->{vroutes} ? 
+        @{$dh->{'instances'}->{$interface}->{$instance}->{vroutes}} : (),
+        trim $_ ];
+    }
+    elsif ($in_vip){
       m/(.*?) dev (.*)/ && do {
         $dh->{'instances'}->{$interface}->{$instance}->{vips} = 
         [ $dh->{'instances'}->{$interface}->{$instance}->{vips} ? 
@@ -146,6 +154,7 @@ sub process_data {
       $in_vip = undef;
       add_to_datahash $dh, $interface, $instance, $in_sync, $1, $2;
       m/Virtual IP/ && do {$in_vip = 1};
+      m/Virtual Routes/ && do {$in_vroute = 1};
       next;
     };
   }
@@ -270,6 +279,14 @@ sub print_detail {
         $dh->{instances}->{$interface}->{$vrid}->{'virtual-ip'};
       foreach my $vip (@{$dh->{instances}->{$interface}->{$vrid}->{vips}}){
          printf "    %s\n", $vip;
+      }
+      printf "\n";
+      if ( defined $dh->{instances}->{$interface}->{$vrid}->{'virtual-routes'}) {
+        printf "  Virtual routes count:\t%s\n",
+          $dh->{instances}->{$interface}->{$vrid}->{'virtual-routes'};
+        foreach my $vroute (@{$dh->{instances}->{$interface}->{$vrid}->{vroutes}}){
+          printf "    %s\n", $vroute;
+        }
       }
       printf "\n";
     }

--- a/scripts/vyatta-keepalived.pl
+++ b/scripts/vyatta-keepalived.pl
@@ -144,6 +144,29 @@ sub keepalived_get_values {
       push @errs, $err;
       next;
     }
+    my @vroutes = $config->listNodes("virtual-route");
+    my @vroutes_parsed = ();
+    my $num_vroutes = scalar(@vroutes);
+    if ($num_vroutes > 0) {
+      foreach my $vroute (@vroutes) {
+        $config->setLevel("$path vrrp vrrp-group $group virtual-route $vroute");
+        if ($config->exists("blackhole")) {
+          push(@vroutes_parsed, "blackhole $vroute");
+        }
+        elsif ($config->exists("next-hop")) {
+          my $next_hop = $config->returnValue("next-hop");
+          push(@vroutes_parsed, "$vroute gw $next_hop");
+        } else {
+          next if $noerr;
+          @loc = split(/ /, "$path vrrp vrrp-group $group virtual-route $vroute");
+          $err = "must define a next-hop or blackhole for virtual-route $vroute";
+          Vyatta::Config::outputError(\@loc, $err);
+          push @errs, $err;
+          next;
+        }
+      }
+      $config->setLevel("$path vrrp vrrp-group $group");
+    }
 
     my $use_vmac = 0;
     my $transition_intf = $intf;
@@ -301,6 +324,13 @@ sub keepalived_get_values {
       $output .= "\t\t$vip\n";
     }
     $output .= "\t\}\n";
+    if ($num_vroutes > 0) {
+      $output .= "\tvirtual_routes \{\n";
+      foreach my $vroute (@vroutes_parsed) {
+        $output .= "\t\t$vroute\n";
+      }
+      $output .= "\t\}\n";
+    }
     if ($run_master_script ne 'null') {
       $output .= "\tnotify_master \"$state_transition_script master ";
       $output .= "$intf $group $transition_intf \'$run_master_script\' @vips\" \n";


### PR DESCRIPTION
I tested this as a cherry-pick-backport to helium in a tiny experiment environment. I'd be interested in all and any comments!

Small caveat: blackhole routes apparently aren't picked up by Quagga and thus don't show up in `show ip route`. Normal routes work flawlessly and have protocol "kernel".